### PR TITLE
Limit tooltip top to -100

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -117,9 +117,7 @@
             __zoom_privileged = getConfig(['zoom', 'privileged'], false);
 
         var __onenter = getConfig(['onenter'], function () {}),
-            __onleave = getConfig(['onleave'], function () {}),
-            __onresize = getConfig(['onresize'], function () {}),
-            __onresized = getConfig(['onresized'], function () {});
+            __onleave = getConfig(['onleave'], function () {});
 
         var __transition_duration = getConfig(['transition', 'duration'], 350);
 
@@ -338,10 +336,10 @@
             context : function () { return "translate(" + margin2.left + "," + margin2.top + ")"; },
             legend : function () { return "translate(" + margin3.left + "," + margin3.top + ")"; },
             x : function () {
-              if (__legend_show === true) {
-                return "translate(0," + (__axis_rotated ? 0 : height) + ")";
-              }
-              return "translate(0," + (__axis_rotated ? 0 : height + margin3.top) + ")";
+                if (__legend_show === true) {
+                    return "translate(0," + (__axis_rotated ? 0 : height) + ")";
+                }
+                return "translate(0," + (__axis_rotated ? 0 : height + margin3.top) + ")";
             },
             y : function () { return "translate(0," + (__axis_rotated ? height : 0) + ")"; },
             y2 : function () { return "translate(" + (__axis_rotated ? 0 : width) + "," + (__axis_rotated ? 1 : 0) + ")"; },
@@ -3721,19 +3719,6 @@
             }
         }
 
-        function generateResize() {
-            var resizeFunctions = [];
-            function callResizeFunctions() {
-                resizeFunctions.forEach(function (f) {
-                    f();
-                });
-            }
-            callResizeFunctions.add = function (f) {
-                resizeFunctions.push(f);
-            };
-            return callResizeFunctions;
-        }
-
         function updateSvgSize() {
             svg.attr('width', currentWidth).attr('height', currentHeight);
             svg.select('#' + clipId).select('rect')
@@ -4331,7 +4316,7 @@
             }
         };
 
-        c3.unload = function (targetIds, done) {
+        c3.unload = function (targetIds) {
             unload(mapToTargetIds(targetIds), function () {
                 redraw({withUpdateOrgXDomain: true, withUpdateXDomain: true, withLegend: __legend_show});
             });

--- a/c3.js
+++ b/c3.js
@@ -2010,7 +2010,7 @@
             }
             // Set tooltip
             tooltip
-                .style("top", tooltipTop + "px")
+                .style("top", Math.max(tooltipTop, -100) + "px")
                 .style("left", tooltipLeft + 'px');
         }
         function hideTooltip() {

--- a/c3.js
+++ b/c3.js
@@ -2011,7 +2011,7 @@
             // Set tooltip
             tooltip
                 .style("top", Math.max(tooltipTop, -100) + "px")
-                .style("left", tooltipLeft + 'px');
+                .style("left", Math.max(tooltipLeft, -20) + 'px');
         }
         function hideTooltip() {
             tooltip.style("display", "none");


### PR DESCRIPTION
* Stops the chart popover from going more than 100px above the charts.
* Stops the popover from going more than 20px to the left of the charts (for mobiles).
* Fixes some linting issues.

**Related pull request: https://github.com/Opsimize/frontend/pull/1405**

![screen shot 2015-02-19 at 17 00 11](https://cloud.githubusercontent.com/assets/5850625/6271545/34164b18-b859-11e4-85d0-e97086c61dcf.png)

~~This pull request may need an adjustment to prevent this going off the left on mobiles.~~

**Mobile**
**Before**
![screen shot 2015-02-19 at 17 16 45](https://cloud.githubusercontent.com/assets/5850625/6271787/2374f654-b85b-11e4-8ad2-a9f6dc41a3cc.png)

**After**
![screen shot 2015-02-19 at 17 16 59](https://cloud.githubusercontent.com/assets/5850625/6271786/2373322e-b85b-11e4-8683-3654587edef0.png)