### PR TITLE
Prevent c3 from affecting body position

### DIFF
--- a/c3.js
+++ b/c3.js
@@ -2668,7 +2668,6 @@
 
             // Define tooltip
             tooltip = d3.select(document.body)
-                .style("position", "relative")
               .append("div")
                 .style("position", "absolute")
                 .style("pointer-events", "none")


### PR DESCRIPTION
c3 was forcing `position: relative;` on the body element, which then affected other styles.

**c3 no longer adding styles**

![screen shot 2015-03-09 at 10 45 08](https://cloud.githubusercontent.com/assets/5850625/6553514/6eafbc16-c649-11e4-935f-e4de10ee85b7.png)

**Tutorials look fine**

![screen shot 2015-03-09 at 10 45 19](https://cloud.githubusercontent.com/assets/5850625/6553515/6ec0356e-c649-11e4-93f0-3c5df42b0606.png)
